### PR TITLE
Extend api

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -8,6 +8,8 @@ module.exports = {
   host: 'localhost',
   crm: {
     host: MOCK_SERVER,
+    fetchConcurrency: 3,
+    waitForRetry: 3000,
   },
   oms: {
     host: MOCK_SERVER,

--- a/index.js
+++ b/index.js
@@ -4,6 +4,29 @@ const bodyParserMW = require('koa-bodyparser');
 
 const router = require('./lib/routes');
 
+const errorMiddleware = async (ctx, next) => {
+  try {
+    await next()
+  } catch (err) {
+    console.error(err);
+
+    ctx.status = err.status || 500;
+    ctx.set('Content-Type', 'application/json');
+
+    return {
+      success: false,
+      error: err.message,
+      data: null,
+    };
+  } finally {
+    return {
+      success: true,
+      error: null,
+      data: ctx.response.body,
+    }
+  }
+};
+
 const logMiddleware = async (ctx, next) => {
   const start = Date.now();
 
@@ -23,6 +46,7 @@ async function start() {
   app
     .use(logMiddleware)
     .use(bodyParserMW())
+    .use(errorMiddleware)
     .use(router.allowedMethods())
     .use(router.routes())
     .listen(config.get('port'));

--- a/lib/models/api.js
+++ b/lib/models/api.js
@@ -1,0 +1,35 @@
+const axios = require('axios');
+const config = require('config');
+
+const delay = (ms) => new Promise(r => setTimeout(r, ms));
+
+const api = axios.create();
+
+const requestsQueue = [];
+let concurrentRequests = 0;
+
+api.interceptors.request.use(async axiosConfig => {
+  requestsQueue.push(axiosConfig);
+
+  while (concurrentRequests >= config.get('crm.fetchConcurrency')) {
+    console.debug(`Crm concurrent request added to queue`, {queueLength: concurrentRequests});
+
+    await delay(config.get('crm.waitForRetry'))
+  }
+
+  ++concurrentRequests;
+
+  return requestsQueue.shift()
+});
+
+api.interceptors.response.use(response => {
+  --concurrentRequests;
+
+  return response
+}, error => {
+  --concurrentRequests;
+
+  throw error
+});
+
+module.exports = api;

--- a/lib/models/users.js
+++ b/lib/models/users.js
@@ -1,0 +1,95 @@
+const config = require('config');
+
+const api = require('./api');
+const cacheModel = require('../services/cache');
+
+class User {
+  constructor({ id, phone, lastName, firstName, balance }) {
+      this.id = id;
+      this.phone = phone;
+      this.lastName = lastName;
+      this.firstName = firstName;
+      this.balance = balance;
+  }
+
+  async findById(id) {
+    const cache = await cacheModel.findOne({
+      where: {id},
+    });
+
+    if (cache) {
+      return cache
+    }
+
+    const response = await api.request({
+      method: 'GET',
+      url: `https://${config.get('crm.host')}/user`,
+      params: {id}
+    });
+
+    const user = await this.fromResponse(response.data);
+
+    await cacheModel.save(user);
+
+    return user;
+  }
+
+  static async create({phone, lastName, firstName, balance}) {
+    const crmUser = {
+      Phone: phone,
+      Last_Name: lastName,
+      First_Name: firstName,
+      Current_Balance: balance,
+    };
+
+    const response = await api.request({
+      method: 'POST',
+      url: `https://${config.get('crm.host')}/user`,
+      data: [crmUser],
+    });
+
+    return response && response.data
+  }
+
+  static async update({id, phone, lastName, firstName, balance}) {
+    const crmUser = {
+      id,
+      ...phone && {Phone: phone},
+      ...lastName && {Last_Name: lastName},
+      ...firstName && {First_Name: firstName},
+      ...balance && {Current_Balance: balance},
+    };
+
+    const response = await api.request({
+      method: 'PUT',
+      url: `https://${config.get('crm.host')}/user`,
+      data: [crmUser],
+    });
+
+    return response && response.data
+  }
+
+  static async delete(id) {
+    const response = await api.request({
+      method: 'PUT',
+      url: `https://${config.get('crm.host')}/user`,
+      params: {id}
+    });
+
+    return response && response.data
+  }
+
+  static fromResponse(data) {
+    console.debug('Crm User model response: ', {data});
+
+    return new User({
+      id: data.id,
+      phone: data.Phone,
+      lastName: data.Last_Name,
+      firstName: data.First_Name,
+      balance: data.Current_Balance,
+    })
+  }
+}
+
+module.exports = User;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,9 +1,61 @@
 const Router = require('koa-router');
 
+const User = require('./models/users');
+const oms = require('./services/oms');
+const inventory = require('./services/inventory');
+
 const router = new Router();
 
 router.get('/health', (ctx) => {
   return ctx.response.body = 'OK';
+});
+
+router.get('/getUser', async (ctx) => {
+  ctx.response.body = await User.findById(ctx.request.query.id);
+  ctx.status = 200;
+});
+
+router.get('/createUser', async (ctx) => {
+  ctx.response.body = await User.create(ctx.request.query);
+  ctx.status = 200;
+});
+
+router.put('/updateUser', async (ctx) => {
+  await User.update(ctx.request.body);
+  ctx.status = 200;
+});
+
+router.get('/deleteUser', async (ctx) => {
+  await User.delete(ctx.request.query.id);
+  ctx.status = 200;
+});
+
+router.post('/orderWithInvoice', async (ctx) => {
+  const orderData = ctx.request.body;
+
+  const orderId = oms.order.create({
+    ...orderData,
+    status: 'new',
+  });
+
+  const invoiceId = oms.invoice.create(orderData);
+
+  for (let { id, count } of orderData.products) {
+    const product = await inventory.product.getById(id);
+
+    await inventory.product.update({
+      ...product,
+      reserved: product.reserved + count
+    });
+  }
+
+  oms.order.update({
+    ...orderData,
+    status: 'ready',
+  });
+
+  ctx.response.body = { orderId, invoiceId };
+  ctx.status = 200;
 });
 
 module.exports = router;


### PR DESCRIPTION
# This PR is an example of a bad work, it is expected from reviewer to identify mistakes

## For reviewer

Please read PR description and do PR review - comment problematic places, propose solutions or just ask questions to the code as you do during usual PR review.
❗ DO NOT hesitate to comment whatever questions and problems you could find ❗

## Problem

We have services respective as a source of truth:
- `crm` for user data
- `oms` for order data
- `inventory` for products

❗ These services are mocked with 1 Postman [collection](https://documenter.getpostman.com/view/10954446/SztD46xp?version=latest)

Our server is a public gateway and we need to extend its functionality with endpoints:
- CRUD for users records in `crm`
- checkout endpoint with following actions:
     - create order with status `new` in `oms`
     - create invoice from the order
     - reserve order products in `inventory` service
     - update order with status `ready`

Please note:
- `crm` has api limits: 
     - number of concurrent requests <= 3, in case of > 3 all our next requests will be blocked for 10sec
     - throughput <= 1000 request / per day is free, every request over this limit will be additionally charged 50cent/request

## Solution
To solve api limitation of `crm` I have used global axios [interceptor](https://github.com/axios/axios#interceptors) - to control how much concurrent request could be send to `crm`.
To reduce total amount of request to `crm` I have added cache to the users server model.
Users api is nice and pretty. This code is ideal and works as expected. No one could comment my code, just approve and deploy.

## Changes
- changed `config/default.js` added params to handle concurrency limits
- changed `lib/index.js` added errorMiddleware to be sure to not kill server in case of failed request
- changed `lib/routes.js` added beautiful api for users and orders
- added `lib/models/api.js` to provide concurrency safe axios version
- added `lib/models/users.js` to provide interfaces to work with user entity in server with cache to reduce `crm` api usage
 
## Testing
Setup server locally and use requests examples:

1)
```
curl --location --request GET 'http://localhost:3003/getUser?id=1'
```
2)
```
curl --location --request GET 'http://localhost:3003/createUser' \
--header 'Content-Type: application/json' \
--data-raw '{
	"phone": "3806660001",
	"lastName": "Johny",
	"firstName": "Pooper",
	"balance": "666"
}'
```
3)
```
curl --location --request PUT 'http://localhost:3003/updateUser' \
--header 'Content-Type: application/json' \
--data-raw '{
	"id": "123123",
	"phone": "3806660001",
	"lastName": "Johny",
	"firstName": "Pooper",
	"balance": "666"
}'
```
4)
```
curl --location --request GET 'http://localhost:3003/deleteUser?id=1'
```
5)
```
curl --location --request POST 'http://localhost:3003/orderWithInvoice' \
--header 'Content-Type: application/json' \
--data-raw '{ 
	"id": "1",
	"code": "4RT6SD",
	"user": {
		"id": "1",
		"name": "Bob"
	},
	"products": [
		{
			"id": "2",
			"count": "4",
			"price": 300
		},{
			"id": "3",
			"count": "5",
			"price": 200
		}
	]
}'
```
